### PR TITLE
fix: replace deprecated resources.ToCSS with css.Sass for hugo compat…

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="{{ $baseUrl }}/css/fontawesome-all.css" />
   <!-- Theme stylesheet, you can customize scss by creating `assets/custom.scss` in your website -->
   {{- $styles := resources.Get "main.scss" | resources.ExecuteAsTemplate
-  "main.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+  "main.scss" . | css.Sass | resources.Minify | resources.Fingerprint }}
   <link rel="stylesheet" href="{{ $styles.RelPermalink }}" {{ template
   "integrity" $styles }}> {{- define "integrity" -}} {{- if (urls.Parse
   .Permalink).Host -}} integrity="{{ .Data.Integrity }}" crossorigin="anonymous"


### PR DESCRIPTION
## Description

Replaced the deprecated resources.ToCSS function with css.Sass in the Hugo theme. This update resolves deprecation warnings introduced in Hugo v0.128.0 and ensures compatibility with future versions where resources.ToCSS will be removed.

## Related Issue

No related issue created. The change addresses a deprecation warning directly encountered during development.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
